### PR TITLE
Cookie-Disclaimer: Fix weird IE behavior when used in box mode

### DIFF
--- a/packages/cookie-disclaimer/src/style.scss
+++ b/packages/cookie-disclaimer/src/style.scss
@@ -15,6 +15,7 @@ $ft-cookie-disclaimer-box-margin: 20px !default;
 
   .disclaimer-text {
     margin: 0;
+    max-width: 100%; // because of IE
   }
 
   &.-visibility-default {


### PR DESCRIPTION
Currently when cookie disclaimer is used in box mode, the text is not wrapped and therefore spreads across the whole site.
This line fixes the problem.