### PR TITLE
DomStateHandler sync states

### DIFF
--- a/packages/dom-state-handler/src/index.js
+++ b/packages/dom-state-handler/src/index.js
@@ -30,7 +30,7 @@ class DomStateHandler extends features.Feature {
     this.instance = new Prototype(this.node)
     this.options.domState.registerStateHandler(this.instance)
     this.addEventListener(this.node, this.instance.getChangeEventName(), () => {
-      this.options.domState.updateState()
+      this.options.domState.updateState(this.instance)
     })
   }
 

--- a/packages/dom-state-handler/src/persistors/dom-state.js
+++ b/packages/dom-state-handler/src/persistors/dom-state.js
@@ -30,17 +30,28 @@ class DomState {
     )
   }
 
-  updateState() {
-    this._state = this.obtainState()
+  updateState(instance) {
+    this._state = this.obtainState(instance)
     this.persistState()
     this.notify()
   }
 
-  obtainState() {
-    return this._stateHandlers.reduce((agg, handler) => {
-      agg[handler.getName()] = handler.getValue()
+  obtainState(instance) {
+    const syncName = instance?.getName()
+    const syncValue = instance?.getValue()
+    let states = this._stateHandlers.reduce((agg, handler) => {
+      let value = '';
+      //const value = handler.getName() === syncName ? syncValue : handler.getValue()
+      if(handler.getName() === syncName){
+        value = syncValue
+        console.log(handler)
+      } else {
+        value = handler.getValue()
+      }
+      agg[handler.getName()] = value
       return agg
     }, {})
+    return states
   }
 
   persistState() {

--- a/packages/dom-state-handler/src/persistors/dom-state.js
+++ b/packages/dom-state-handler/src/persistors/dom-state.js
@@ -39,19 +39,16 @@ class DomState {
   obtainState(instance) {
     const syncName = instance?.getName()
     const syncValue = instance?.getValue()
-    let states = this._stateHandlers.reduce((agg, handler) => {
-      let value = '';
-      //const value = handler.getName() === syncName ? syncValue : handler.getValue()
+
+    return this._stateHandlers.reduce((agg, handler) => {
       if(handler.getName() === syncName){
-        value = syncValue
-        console.log(handler)
+        agg[handler.getName()] = syncValue
+        handler.setValue(syncValue)
       } else {
-        value = handler.getValue()
+        agg[handler.getName()] = handler.getValue()
       }
-      agg[handler.getName()] = value
       return agg
     }, {})
-    return states
   }
 
   persistState() {

--- a/packages/dom-state-handler/stories/index.stories.js
+++ b/packages/dom-state-handler/stories/index.stories.js
@@ -57,6 +57,31 @@ const DomStatehandlerMarkup = `
 </div>
 `
 
+const SyncStatesMarkup = `<div>
+<div>fruits:</div>
+  <select name="fruits" data-feature="dom-state-handler" data-cy="select1">
+    <option value="orange" data-cy="orange">orange</option>
+    <option value="violet" data-cy="violet">violet</option>
+    <option value="yellow" data-cy="yellow">yellow</option>
+  </select>
+
+  <div style="margin-top:20px;">option-other:</div>
+  <select name="option-other" data-feature="dom-state-handler" data-cy="select2">
+    <option value="option1">Option 1</option>
+    <option value="option2">Option 2</option>
+  </select>
+
+  <div style="margin-top:20px;">fruits:</div>
+  <div data-feature="dom-state-handler" data-state-handler-type="radio-group">
+    <input id="orange" type="radio" name="fruits" value="orange" data-cy="radio1" />
+    <label for="orange">orange</label>
+    <input id="violet" type="radio" name="fruits" value="violet" data-cy="radio2" checked/>
+    <label for="violet">violet</label>
+    <input id="yellow" type="radio" name="fruits" value="yellow" data-cy="radio3" />
+    <label for="yellow">yellow</label>
+  </div>
+</div>`
+
 const LazyFilterGridMarkup = `
 <style>
 .grid {position: relative; }
@@ -162,6 +187,28 @@ storiesOf('DomStateHandler', module)
         resetFeature(features, 'dom-state-handler')
         features.add('dom-state-handler', DomStateHandler, {
           domState: new UrlParameter(
+            object('domStateOptions', {
+              namespace: 'default-namespace',
+              restorePersisted: true
+            })
+          )
+        })
+        features.init(document.body)
+      })
+    },
+    {
+      notes: {
+        markdown: DomStateHandlerDocs
+      }
+    }
+  )
+  .add(
+    'Sync States',
+    () => {
+      return initializeDemo(SyncStatesMarkup, () => {
+        resetFeature(features, 'dom-state-handler')
+        features.add('dom-state-handler', DomStateHandler, {
+          domState: new LocalStorage(
             object('domStateOptions', {
               namespace: 'default-namespace',
               restorePersisted: true

--- a/packages/dom-state-handler/stories/index.stories.js
+++ b/packages/dom-state-handler/stories/index.stories.js
@@ -208,7 +208,7 @@ storiesOf('DomStateHandler', module)
       return initializeDemo(SyncStatesMarkup, () => {
         resetFeature(features, 'dom-state-handler')
         features.add('dom-state-handler', DomStateHandler, {
-          domState: new LocalStorage(
+          domState: new UrlFragment(
             object('domStateOptions', {
               namespace: 'default-namespace',
               restorePersisted: true


### PR DESCRIPTION
Sync states between inputs with the same name.
Example usage: Use radios on desktop bp and dropdown on mobile bp.